### PR TITLE
Import cloudwatch logs resource policies

### DIFF
--- a/introspector/aws/logs.py
+++ b/introspector/aws/logs.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from introspector import ImportWriter, PathStack
 from introspector.aws.fetch import Proxy, ServiceProxy
+from introspector.aws.mapper_fns import policy_statement
 from introspector.aws.region import RegionCache
 from introspector.aws.svc import RegionalService, ServiceSpec, resource_gate
 from introspector.models import ImportJob, Resource
@@ -34,7 +35,6 @@ def _import_log_groups(proxy: ServiceProxy):
 
 
 def normalize_resource_policies(policies: List) -> Dict[str, List[Any]]:
-  from introspector.aws.map import policy_statement
   resource_statements_map: Dict[str, List[Any]] = {}
   for policy_data in policies:
     name = policy_data.get('policyName', 'unnamed')

--- a/introspector/aws/logs.py
+++ b/introspector/aws/logs.py
@@ -1,8 +1,15 @@
+from collections import defaultdict
+import json
 import logging
-from typing import Any, Dict, Iterator, Tuple
+from typing import Any, Dict, List, Iterator, Iterable, Tuple
 
-from introspector.aws.fetch import ServiceProxy
+from sqlalchemy.orm import Session
+
+from introspector import ImportWriter, PathStack
+from introspector.aws.fetch import Proxy, ServiceProxy
+from introspector.aws.region import RegionCache
 from introspector.aws.svc import RegionalService, ServiceSpec, resource_gate
+from introspector.models import ImportJob, Resource
 
 _log = logging.getLogger(__name__)
 
@@ -24,6 +31,89 @@ def _import_log_groups(proxy: ServiceProxy):
     groups = groups_resp[1].get('logGroups', [])
     for group_data in groups:
       yield 'LogGroup', _import_log_group(proxy, group_data)
+
+
+def normalize_resource_policies(policies: List) -> Dict[str, List[Any]]:
+  from introspector.aws.map import policy_statement
+  resource_statements_map: Dict[str, List[Any]] = {}
+  for policy_data in policies:
+    name = policy_data.get('policyName', 'unnamed')
+    document = json.loads(policy_data.get('policyDocument', '{}'))
+    for statement in document.get('Statement', []):
+      statement_common = policy_statement(statement)
+      other_keys = [
+          key for key in statement_common.keys()
+          if key not in ('Resource', 'Sid')
+      ]
+      sid = statement_common.get('Sid', 'nosid')
+      for resource in statement_common.get('Resource', []):
+        to_add = {
+            key: value
+            for key, value in statement_common.items() if key in other_keys
+        }
+        to_add['Resource'] = [resource]
+        to_add['Sid'] = '_'.join([name, sid])
+        resource_statements = resource_statements_map.get(resource, [])
+        resource_statements.append(to_add)
+        resource_statements_map[resource] = resource_statements
+  return resource_statements_map
+
+
+def _import_resource_policies(proxy: ServiceProxy) -> Dict[str, List[Any]]:
+  policies_resp = proxy.list('describe_resource_policies')
+  if policies_resp is not None:
+    policies = policies_resp[1].get('resourcePolicies', [])
+    return normalize_resource_policies(policies)
+  return {}
+
+
+def _log_group_uris_by_prefix(db: Session, provider_account_id: int,
+                              account_id: str, region: str, prefix: str) -> Iterable[str]:
+  prefix_with_wildcards = prefix.replace('*', '%')
+  # if the prefix has a spot for an account id, fill it in
+  parts = prefix_with_wildcards.split(':')
+  if len(parts) < 5:
+    prefix_parts = ['arn', 'aws', 'logs', region, account_id, '%']
+    for incoming, expected in zip(parts, prefix_parts):
+      if incoming != expected and incoming != '%':
+        return []
+    # TODO: partition
+    parts = ['arn', 'aws', 'logs', region, account_id, '%']
+  else:
+    parts[4] = account_id
+    # Handle the case where the resource is 'arn:aws:logs:region:*'
+    if len(parts) == 5:
+      parts.append('%')
+  resolved_prefix = ':'.join(parts)
+  return map(lambda row: row[0], db.query(Resource.uri).filter(
+      Resource.provider_account_id == provider_account_id,
+      Resource.service == 'logs',
+      Resource.provider_type == 'LogGroup',
+      Resource.uri.like(resolved_prefix)).all())
+
+
+def _make_policy(statements):
+  return {'Version': '2012-10-17', 'Statement': statements}
+
+
+def add_logs_resource_policies(db: Session, proxy: Proxy,
+                               region_cache: RegionCache, writer: ImportWriter,
+                               import_job: ImportJob, ps: PathStack,
+                               account_id: str):
+  for region in region_cache.regions_for_service('logs'):
+    logs_proxy = proxy.service('logs', region)
+    policies = _import_resource_policies(logs_proxy)
+    synthesized = defaultdict(lambda: [])
+    for prefix, statements in policies.items():
+      for log_group_uri in _log_group_uris_by_prefix(
+          db, import_job.provider_account_id, account_id, region, prefix):
+        synthesized[log_group_uri] += statements
+    for uri, statements in synthesized.items():
+      policy = _make_policy(statements)
+      writer(ps, 'ResourcePolicy', {
+          'Policy': policy,
+          'arn': uri
+      }, {'region': region})
 
 
 def _import_logs_region(proxy: ServiceProxy, region: str,

--- a/introspector/aws/map.py
+++ b/introspector/aws/map.py
@@ -1,7 +1,5 @@
 import logging
 import os
-import re
-from typing import Any, Dict, List, Optional, Union
 
 from sqlalchemy.orm import Session
 
@@ -11,6 +9,7 @@ from introspector.aws.ec2_adjunct import find_adjunct_data
 from introspector.aws.fetch import Proxy
 from introspector.aws.iam import synthesize_account_root
 from introspector.aws.logs import add_logs_resource_policies
+from introspector.aws.mapper_fns import get_mapper_fns
 from introspector.aws.svc import ImportSpec, resource_gate, service_gate
 from introspector.aws.region import RegionCache
 from introspector.aws.uri import get_arn_fn
@@ -21,181 +20,6 @@ from introspector.mapper import DivisionURI, load_transforms, Mapper
 from introspector.models import ImportJob
 
 _log = logging.getLogger(__name__)
-
-
-def _zone_to_region(zone: str, **_) -> str:
-  return zone[:-1]
-
-
-_KEY_ATTRS = ['Key', 'key', 'TagKey']
-
-
-def _aws_tag_key(item: Dict) -> str:
-  for attr in _KEY_ATTRS:
-    key = item.get(attr)
-    if key is not None:
-      return key
-  raise GFError(f'Cannot find tag key in {item}')
-
-
-_VALUE_ATTRS = ['Value', 'value', 'TagValue']
-
-
-def _aws_tag_value(item: Dict) -> str:
-  for attr in _VALUE_ATTRS:
-    value = item.get(attr)
-    if value is not None:
-      return value
-  raise GFError(f'Cannot find tag value in {item}')
-
-
-def _tag_list_to_object(tags: Optional[List[Dict[str, str]]],
-                        **_) -> Dict[str, str]:
-  if tags is None or len(tags) == 0:
-    return {}
-  return {_aws_tag_key(item): _aws_tag_value(item) for item in tags}
-
-
-def _lambda_alias_relations(parent_uri, target_raw, **kwargs):
-  initial_version = target_raw['FunctionVersion']
-  fn_arn = target_raw['FunctionArn']
-
-  def version_arn(v: str) -> str:
-    return f'{fn_arn}:{v}'
-
-  version_total = 0
-  weights = target_raw.get('RoutingConfig', {}).get('AdditionalVersionWeights',
-                                                    {})
-  for version, weight in weights.items():
-    version_total += weight
-    target_uri = version_arn(version)
-    yield parent_uri, 'forwards-to', version_arn(version), [{
-        'name': 'weight',
-        'value': weight
-    }]
-  remaining = 1.0 - version_total
-  target_uri = version_arn(initial_version)
-  yield parent_uri, 'forwards-to', version_arn(initial_version), [{
-      'name':
-      'weight',
-      'value':
-      remaining
-  }]
-
-
-def _arrayize(inval: Union[str, List[str]]) -> List[str]:
-  if isinstance(inval, str):
-    return [inval]
-  return sorted(inval)
-
-
-ALL_DIGITS = re.compile(r'^[0-9]{10}[0-9]*$')
-
-
-def _normalize_principal_map(
-    raw: Union[str, Dict[str, Any]]) -> Dict[str, List[Any]]:
-  result = {}
-  if not isinstance(raw, dict):
-    if raw != '*':
-      _log.warn(f'Invalid string literal principal {raw}')
-      return {}
-    else:
-      return {'AWS': ['*']}
-  for key, value in raw.items():
-    values = _arrayize(value)
-    if key == 'AWS':
-      # normalize account ids
-      principals = []
-      for principal in values:
-        if ':' not in principal and ALL_DIGITS.match(principal) is not None:
-          principals.append(f'arn:aws:iam::{principal}:root')
-        else:
-          principals.append(principal)
-      values = principals
-    result[key] = values
-  return result
-
-
-EFFECTS = {'allow': 'Allow', 'deny': 'Deny'}
-
-
-def policy_statement(raw: Dict[str, Any]) -> Dict[str, Any]:
-  result = {}
-  lc = {k.lower(): v for k, v in raw.items()}
-
-  def _normalize(s: str, fn):
-    val = lc.get(s.lower())
-    if val is not None:
-      result[s] = fn(val)
-
-  sid = lc.get('sid')
-  if sid is not None:
-    result['Sid'] = sid
-  _normalize('Principal', _normalize_principal_map)
-  _normalize('NotPrincipal', _normalize_principal_map)
-  result['Effect'] = EFFECTS[lc['effect'].lower()]
-  _normalize('Action', _arrayize)
-  _normalize('NotAction', _arrayize)
-  _normalize('Resource', _arrayize)
-  _normalize('NotResource', _arrayize)
-  condition = lc.get('condition')
-  if condition is not None:
-    # TODO: deeper normalization
-    result['Condition'] = condition
-  return result
-
-
-EMPTY_POLICY = {'Version': '2012-10-17', 'Statement': []}
-
-
-def _policy(policy: Optional[Dict[str, Any]]) -> Dict[str, Any]:
-  if policy is None:
-    return EMPTY_POLICY
-  result = {}
-  lc = {k.lower(): v for k, v in policy.items()}
-  result['Version'] = lc.get('version', '2012-10-17')
-  policy_id = lc.get('id')
-  if policy_id is not None:
-    result['Id'] = policy_id
-  result['Statement'] = [policy_statement(s) for s in lc.get('statement', [])]
-  return result
-
-
-def _policy_map(m: Optional[Dict[str, Dict[str, Any]]]) -> Dict[str, Any]:
-  if m is None or len(m) == 0:
-    return EMPTY_POLICY
-  policies = [_policy(policy) for policy in m.values()]
-  statements = []
-  for policy in policies:
-    statements += policy.get('Statement', [])
-  return {
-      'Version': '2012-10-17',
-      'Id': 'Synthesized from map',
-      'Statement': statements
-  }
-
-
-AWS_TRANSFORMS = {
-    'aws_zone_to_region': _zone_to_region,
-    'aws_tags': _tag_list_to_object,
-    'aws_lambda_alias': _lambda_alias_relations,
-    'aws_policy': _policy,
-    'aws_policy_map': _policy_map
-}
-
-
-def _get_aws_not_in_org(import_job: ImportJob):
-  # TODO: rewrite this. pretty sure we have the list of accounts
-  account_paths = import_job.configuration['aws_graph']['accounts']
-
-  def _aws_not_in_org(account_id: str, **kwargs) -> bool:
-    for accounts in account_paths.values():
-      for account in accounts:
-        if account['Id'] == account_id:
-          return False
-    return True
-
-  return _aws_not_in_org
 
 
 class AWSDivisionURI(DivisionURI):
@@ -245,11 +69,13 @@ def _get_mapper(import_job: ImportJob,
                                 org_config['Id'])
   transform_path = os.path.join(os.path.dirname(__file__), 'transforms')
   transforms = load_transforms(transform_path)
-  fns = AWS_TRANSFORMS.copy()
-  fns['aws_not_in_org'] = _get_aws_not_in_org(import_job)
-  if extra_fns is not None:
-    for fn, impl in extra_fns.items():
-      fns[fn] = impl
+  account_paths = import_job.configuration['aws_graph']['accounts']
+  account_ids = []
+  for accounts in account_paths.values():
+    for account in accounts:
+      account_ids.append(account['Id'])
+  fns = get_mapper_fns(account_ids, extra_fns)
+
   return Mapper(transforms,
                 import_job.provider_account_id,
                 division_uri,

--- a/introspector/aws/mapper_fns.py
+++ b/introspector/aws/mapper_fns.py
@@ -1,0 +1,173 @@
+import logging
+import re
+from typing import Any, Dict, List, Optional, Union
+
+from introspector.error import GFError
+
+ALL_DIGITS = re.compile(r'^[0-9]{10}[0-9]*$')
+
+_log = logging.getLogger(__name__)
+
+def _zone_to_region(zone: str, **_) -> str:
+  return zone[:-1]
+
+def _arrayize(inval: Union[str, List[str]]) -> List[str]:
+  if isinstance(inval, str):
+    return [inval]
+  return sorted(inval)
+
+def _normalize_principal_map(
+    raw: Union[str, Dict[str, Any]]) -> Dict[str, List[Any]]:
+  result = {}
+  if not isinstance(raw, dict):
+    if raw != '*':
+      _log.warn(f'Invalid string literal principal {raw}')
+      return {}
+    else:
+      return {'AWS': ['*']}
+  for key, value in raw.items():
+    values = _arrayize(value)
+    if key == 'AWS':
+      # normalize account ids
+      principals = []
+      for principal in values:
+        if ':' not in principal and ALL_DIGITS.match(principal) is not None:
+          principals.append(f'arn:aws:iam::{principal}:root')
+        else:
+          principals.append(principal)
+      values = principals
+    result[key] = values
+  return result
+
+EFFECTS = {'allow': 'Allow', 'deny': 'Deny'}
+
+
+def policy_statement(raw: Dict[str, Any]) -> Dict[str, Any]:
+  result = {}
+  lc = {k.lower(): v for k, v in raw.items()}
+
+  def _normalize(s: str, fn):
+    val = lc.get(s.lower())
+    if val is not None:
+      result[s] = fn(val)
+
+  sid = lc.get('sid')
+  if sid is not None:
+    result['Sid'] = sid
+  _normalize('Principal', _normalize_principal_map)
+  _normalize('NotPrincipal', _normalize_principal_map)
+  result['Effect'] = EFFECTS[lc['effect'].lower()]
+  _normalize('Action', _arrayize)
+  _normalize('NotAction', _arrayize)
+  _normalize('Resource', _arrayize)
+  _normalize('NotResource', _arrayize)
+  condition = lc.get('condition')
+  if condition is not None:
+    # TODO: deeper normalization
+    result['Condition'] = condition
+  return result
+
+EMPTY_POLICY = {'Version': '2012-10-17', 'Statement': []}
+
+
+def _policy(policy: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+  if policy is None:
+    return EMPTY_POLICY
+  result = {}
+  lc = {k.lower(): v for k, v in policy.items()}
+  result['Version'] = lc.get('version', '2012-10-17')
+  policy_id = lc.get('id')
+  if policy_id is not None:
+    result['Id'] = policy_id
+  result['Statement'] = [policy_statement(s) for s in lc.get('statement', [])]
+  return result
+
+def _policy_map(m: Optional[Dict[str, Dict[str, Any]]]) -> Dict[str, Any]:
+  if m is None or len(m) == 0:
+    return EMPTY_POLICY
+  policies = [_policy(policy) for policy in m.values()]
+  statements = []
+  for policy in policies:
+    statements += policy.get('Statement', [])
+  return {
+      'Version': '2012-10-17',
+      'Id': 'Synthesized from map',
+      'Statement': statements
+  }
+
+_KEY_ATTRS = ['Key', 'key', 'TagKey']
+
+
+def _aws_tag_key(item: Dict) -> str:
+  for attr in _KEY_ATTRS:
+    key = item.get(attr)
+    if key is not None:
+      return key
+  raise GFError(f'Cannot find tag key in {item}')
+
+
+_VALUE_ATTRS = ['Value', 'value', 'TagValue']
+
+
+def _aws_tag_value(item: Dict) -> str:
+  for attr in _VALUE_ATTRS:
+    value = item.get(attr)
+    if value is not None:
+      return value
+  raise GFError(f'Cannot find tag value in {item}')
+
+
+def _tag_list_to_object(tags: Optional[List[Dict[str, str]]],
+                        **_) -> Dict[str, str]:
+  if tags is None or len(tags) == 0:
+    return {}
+  return {_aws_tag_key(item): _aws_tag_value(item) for item in tags}
+
+
+def _lambda_alias_relations(parent_uri, target_raw, **kwargs):
+  initial_version = target_raw['FunctionVersion']
+  fn_arn = target_raw['FunctionArn']
+
+  def version_arn(v: str) -> str:
+    return f'{fn_arn}:{v}'
+
+  version_total = 0
+  weights = target_raw.get('RoutingConfig', {}).get('AdditionalVersionWeights',
+                                                    {})
+  for version, weight in weights.items():
+    version_total += weight
+    target_uri = version_arn(version)
+    yield parent_uri, 'forwards-to', version_arn(version), [{
+        'name': 'weight',
+        'value': weight
+    }]
+  remaining = 1.0 - version_total
+  target_uri = version_arn(initial_version)
+  yield parent_uri, 'forwards-to', version_arn(initial_version), [{
+      'name':
+      'weight',
+      'value':
+      remaining
+  }]
+
+AWS_TRANSFORMS = {
+    'aws_zone_to_region': _zone_to_region,
+    'aws_tags': _tag_list_to_object,
+    'aws_lambda_alias': _lambda_alias_relations,
+    'aws_policy': _policy,
+    'aws_policy_map': _policy_map
+}
+
+def _get_aws_not_in_org(account_ids: List[str]):
+  def _aws_not_in_org(account_id: str, **kwargs) -> bool:
+    return account_id in account_ids
+
+  return _aws_not_in_org
+
+def get_mapper_fns(account_ids: List[str], extra_fns=None):
+  fns = AWS_TRANSFORMS.copy()
+  fns['aws_not_in_org'] = _get_aws_not_in_org(account_ids)
+  if extra_fns is not None:
+    for fn, impl in extra_fns.items():
+      fns[fn] = impl
+  return fns

--- a/introspector/aws/transforms/logs/ResourcePolicy.yml
+++ b/introspector/aws/transforms/logs/ResourcePolicy.yml
@@ -1,0 +1,12 @@
+version: 1
+partials:
+  - uri:
+      uri: arn
+    attributes:
+      provider:
+        - Policy
+      custom:
+        Metadata:
+          Policy:
+            path: Policy
+            transform: aws_policy

--- a/introspector/cli/account/aws.py
+++ b/introspector/cli/account/aws.py
@@ -103,6 +103,7 @@ def import_aws_cmd(debug: bool, force: bool, dry_run: bool,
         refresh_views(db, reloaded_import_job.provider_account_id)
         reloaded_import_job.mark_complete(exceptions=[])
       except:
+        _log.error('exception caught in map', exc_info=True)
         exception = traceback.format_exc()
         reloaded_import_job.mark_complete(exceptions=[exception])
     else:

--- a/introspector/queries/0022-aws_logs_loggroup.sql
+++ b/introspector/queries/0022-aws_logs_loggroup.sql
@@ -12,6 +12,8 @@ INSERT INTO aws_logs_loggroup (
   tags,
   metricfilters,
   _tags,
+  policy,
+  _policy,
   _account_id
 )
 SELECT
@@ -28,6 +30,8 @@ SELECT
   tags.attr_value::jsonb AS tags,
   metricfilters.attr_value::jsonb AS metricfilters,
   _tags.attr_value::jsonb AS _tags,
+  policy.attr_value::jsonb AS policy,
+  _policy.attr_value::jsonb AS _policy,
   
     _account_id.target_id AS _account_id
 FROM
@@ -74,6 +78,14 @@ FROM
     ON _tags.resource_id = R.id
     AND _tags.type = 'Metadata'
     AND lower(_tags.attr_name) = 'tags'
+  LEFT JOIN resource_attribute AS policy
+    ON policy.resource_id = R.id
+    AND policy.type = 'provider'
+    AND lower(policy.attr_name) = 'policy'
+  LEFT JOIN resource_attribute AS _policy
+    ON _policy.resource_id = R.id
+    AND _policy.type = 'Metadata'
+    AND lower(_policy.attr_name) = 'policy'
   LEFT JOIN (
     SELECT
       _aws_organizations_account_relation.resource_id AS resource_id,
@@ -118,6 +130,8 @@ SET
     tags = EXCLUDED.tags,
     metricfilters = EXCLUDED.metricfilters,
     _tags = EXCLUDED._tags,
+    policy = EXCLUDED.policy,
+    _policy = EXCLUDED._policy,
     _account_id = EXCLUDED._account_id
   ;
 

--- a/migrations/provider/aws/20210306003904_add_policy_to_loggroup.sql
+++ b/migrations/provider/aws/20210306003904_add_policy_to_loggroup.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+ALTER TABLE aws_logs_loggroup ADD COLUMN policy JSONB;
+ALTER TABLE aws_logs_loggroup ADD COLUMN _policy JSONB;
+
+-- migrate:down
+ALTER TABLE aws_logs_loggroup DROP COLUMN policy;
+ALTER TABLE aws_logs_loggroup DROP COLUMN _policy;

--- a/tests/aws_mapper_test.py
+++ b/tests/aws_mapper_test.py
@@ -1,7 +1,7 @@
 import json
 
 from introspector.aws.logs import normalize_resource_policies
-from introspector.aws.map import AWS_TRANSFORMS
+from introspector.aws.mapper_fns import AWS_TRANSFORMS
 
 def test_account_principal():
   policy = {
@@ -24,26 +24,3 @@ def test_account_principal():
   from pprint import pprint
   pprint(normalized)
   assert normalized['Statement'][0]['Principal']['AWS'][0] == 'arn:aws:iam::0123456789:root'
-
-def test_logs_resource_policies():
-  fixture = [
-    {
-      'policyName': 'policy1',
-      'policyDocument': json.dumps({
-        'Version': 'dummy',
-        'Statement': [
-          {
-            'Resource': [
-              'a:b/*',
-              'c'
-            ],
-            'Effect': 'Allow'
-          }
-        ]
-      })
-    }
-  ]
-  from pprint import pprint
-  result = normalize_resource_policies(fixture)
-  pprint(result)
-  assert False

--- a/tests/aws_mapper_test.py
+++ b/tests/aws_mapper_test.py
@@ -1,3 +1,6 @@
+import json
+
+from introspector.aws.logs import normalize_resource_policies
 from introspector.aws.map import AWS_TRANSFORMS
 
 def test_account_principal():
@@ -21,3 +24,26 @@ def test_account_principal():
   from pprint import pprint
   pprint(normalized)
   assert normalized['Statement'][0]['Principal']['AWS'][0] == 'arn:aws:iam::0123456789:root'
+
+def test_logs_resource_policies():
+  fixture = [
+    {
+      'policyName': 'policy1',
+      'policyDocument': json.dumps({
+        'Version': 'dummy',
+        'Statement': [
+          {
+            'Resource': [
+              'a:b/*',
+              'c'
+            ],
+            'Effect': 'Allow'
+          }
+        ]
+      })
+    }
+  ]
+  from pprint import pprint
+  result = normalize_resource_policies(fixture)
+  pprint(result)
+  assert False


### PR DESCRIPTION
- Import log policies and fan them out over log groups
- Move aws-specific mapping transforms to their own file, so they can be imported without importing all of the mapping code.