### PR TITLE
Skip relations if uri components are missing

### DIFF
--- a/introspector/aws/transforms/cloudwatch/MetricAlarm.yml
+++ b/introspector/aws/transforms/cloudwatch/MetricAlarm.yml
@@ -42,9 +42,7 @@ resources:
           transform: aws_tags
   relations:
   - relation: fires-on
-    path:
-      metric_name: MetricName
-      metric_namespace: Namespace
+    path: ''
     uri:
       service:
         value: cloudwatch

--- a/introspector/mapper.py
+++ b/introspector/mapper.py
@@ -548,9 +548,16 @@ class Mapper:
                       parent_args=parent_args)
         continue
       target_args = {'parent_uri': uri_args.copy(), 'service': service}
+      skip = False
       for key, spec in relation_spec['uri'].items():
         value = self.value_from_spec(spec, target, parent=raw)
+        if value is None:
+          skip = True
+          _log.debug(f'Missing value for {spec} in {raw}, skipping relation')
+          break
         target_args[key] = value
+      if skip:
+        continue
       try:
         target_uri = uri_fn(**target_args, **parent_args, context=ctx)
       except:


### PR DESCRIPTION
Some relations are optional, like network interface -> ec2 instance.

Also fix an incorrect path for metric alarms, causing us to miss some relations.

Fixes #14 