### PR TITLE
Add AWS account id to config recorders and cloudwatch metrics

### DIFF
--- a/introspector/delta/resource.py
+++ b/introspector/delta/resource.py
@@ -311,9 +311,10 @@ def map_resource_prefix(db: Session,
     import_resource_name = resource_name \
       if resource_name is not None \
         else raw_import.resource_name
+    context = raw_import.context or {}
+    context['path'] = raw_import.path
     for mapped, attrs in mapper.map_resources(raw_import.raw_resources(),
-                                              raw_import.context or {},
-                                              raw_import.service,
+                                              context, raw_import.service,
                                               import_resource_name, uri_fn):
       apply_mapped_attrs(db,
                          import_job,


### PR DESCRIPTION
 - Include the path in the context for uri functions. This allows use of things like org and account ids
 - Include account id in made-up URIs. Some resources don't have published arns, and may conflict between accounts in the same organization (and hence same `provider_account_id`) if the URIs don't also include the account id.
   - config recorder
   - cloudwatch metric

Fixes #18 
 